### PR TITLE
Stop using gopkg.in for gin since its broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ package main
 import (
 	"time"
 
-	"gopkg.in/gin-contrib/cors.v1"
-	"gopkg.in/gin-gonic/gin.v1"
+	cors "gopkg.in/gin-contrib/cors.v1"
+	"github.com/gin-gonic/gin"
 )
 
 func main() {

--- a/config.go
+++ b/config.go
@@ -3,7 +3,7 @@ package cors
 import (
 	"net/http"
 
-	"gopkg.in/gin-gonic/gin.v1"
+	"github.com/gin-gonic/gin"
 )
 
 type cors struct {

--- a/cors.go
+++ b/cors.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/gin-gonic/gin.v1"
+	"github.com/gin-gonic/gin"
 )
 
 // Config represents all available options for the middleware.

--- a/cors_test.go
+++ b/cors_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/gin-gonic/gin.v1"
 )
 
 func init() {

--- a/examples/example.go
+++ b/examples/example.go
@@ -3,8 +3,8 @@ package main
 import (
 	"time"
 
-	"gopkg.in/gin-contrib/cors.v1"
-	"gopkg.in/gin-gonic/gin.v1"
+	"github.com/gin-gonic/gin"
+	cors "gopkg.in/gin-contrib/cors.v1"
 )
 
 func main() {


### PR DESCRIPTION
Reverts #6.

Same reasoning as:

https://github.com/gin-gonic/contrib/issues/133
https://github.com/gin-contrib/sessions/pull/9
https://github.com/gin-gonic/gin/issues/828
