### PR TITLE
add support for wildcard cors origin

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -69,8 +69,8 @@ func (c Config) Validate() error {
 		return errors.New("conflict settings: all origins disabled")
 	}
 	for _, origin := range c.AllowOrigins {
-		if !strings.HasPrefix(origin, "http://") && !strings.HasPrefix(origin, "https://") {
-			return errors.New("bad origin: origins must include http:// or https://")
+		if origin != "*" && !strings.HasPrefix(origin, "http://") && !strings.HasPrefix(origin, "https://") {
+			return errors.New("bad origin: origins must either be '*' or include http:// or https://")
 		}
 	}
 	return nil


### PR DESCRIPTION
you currently can't use the wildcard cors origin, it must start with either http:// or https://