### PR TITLE
Added chrome-extension:// origin support

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -67,8 +67,8 @@ func (c Config) Validate() error {
 		return errors.New("conflict settings: all origins disabled")
 	}
 	for _, origin := range c.AllowOrigins {
-		if origin != "*" && !strings.HasPrefix(origin, "http://") && !strings.HasPrefix(origin, "https://") {
-			return errors.New("bad origin: origins must either be '*' or include http:// or https://")
+		if origin != "*" && !strings.HasPrefix(origin, "http://") && !strings.HasPrefix(origin, "https://") && !strings.HasPrefix(origin, "chrome-extension://") {
+			return errors.New("bad origin: origins must either be '*' or include http:// or https:// or chrome-extension://")
 		}
 	}
 	return nil


### PR DESCRIPTION
Allowing only *, http, and https in allowed origins prevents users from allowing Chrome Extensions without using AllowOriginFunc. This change allows entires with the prefix chrome-extension:// to be allowed.