### PR TITLE
Add support of browser extensions schemas

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,17 @@ type cors struct {
 	preflightHeaders http.Header
 }
 
+var (
+	AllowedSchemas = []string{
+		"http://",
+		"https://",
+		"chrome-extension://",
+		"safari-extension://",
+		"moz-extension://",
+		"ms-browser-extension://",
+	}
+)
+
 func newCors(config Config) *cors {
 	if err := config.Validate(); err != nil {
 		panic(err.Error())
@@ -37,11 +48,15 @@ func (cors *cors) applyCors(c *gin.Context) {
 		return
 	}
 	host := c.Request.Header.Get("Host")
-	if origin == "http://"+host || origin == "https://"+host {
-		// request is not a CORS request but have origin header.
-		// for example, use fetch api
-		return
+
+	for _, schema := range AllowedSchemas {
+		if origin != schema+host {
+			// request is not a CORS request but have origin header.
+			// for example, use fetch api
+			return
+		}
 	}
+
 	if !cors.validateOrigin(origin) {
 		c.AbortWithStatus(http.StatusForbidden)
 		return

--- a/cors.go
+++ b/cors.go
@@ -67,8 +67,10 @@ func (c Config) Validate() error {
 		return errors.New("conflict settings: all origins disabled")
 	}
 	for _, origin := range c.AllowOrigins {
-		if origin != "*" && !strings.HasPrefix(origin, "http://") && !strings.HasPrefix(origin, "https://") {
-			return errors.New("bad origin: origins must either be '*' or include http:// or https://")
+		for _, schema := range AllowedSchemas {
+			if origin != "*" && !strings.HasPrefix(origin, schema) {
+				return errors.New("bad origin: origins must either be '*' or include " + strings.Join(AllowedSchemas, ","))
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
At the moment only supported schemas are - **http://**, **https://** and ***** wildcard.
This PR adds **AllowedSchemas** configurations to add the **ability to extend schemas list**.
By this change, I want to add an option to **send requests from browser extensions**.
I saw that there was PR for only chrome-extension:// scheme, but this change is a more general way to handle that.