### PR TITLE
rename Allowed to Allow matching Field names

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -12,21 +12,21 @@ import (
 type Config struct {
 	AllowAllOrigins bool
 
-	// AllowedOrigins is a list of origins a cross-domain request can be executed from.
+	// AllowOrigins is a list of origins a cross-domain request can be executed from.
 	// If the special "*" value is present in the list, all origins will be allowed.
 	// Default value is []
 	AllowOrigins []string
 
 	// AllowOriginFunc is a custom function to validate the origin. It take the origin
 	// as argument and returns true if allowed or false otherwise. If this option is
-	// set, the content of AllowedOrigins is ignored.
+	// set, the content of AllowOrigins is ignored.
 	AllowOriginFunc func(origin string) bool
 
-	// AllowedMethods is a list of methods the client is allowed to use with
+	// AllowMethods is a list of methods the client is allowed to use with
 	// cross-domain requests. Default value is simple methods (GET and POST)
 	AllowMethods []string
 
-	// AllowedHeaders is list of non simple headers the client is allowed to use with
+	// AllowHeaders is list of non simple headers the client is allowed to use with
 	// cross-domain requests.
 	AllowHeaders []string
 
@@ -97,7 +97,7 @@ func (c Config) validateAllowedSchemas(origin string) bool {
 // Validate is check configuration of user defined.
 func (c *Config) Validate() error {
 	if c.AllowAllOrigins && (c.AllowOriginFunc != nil || len(c.AllowOrigins) > 0) {
-		return errors.New("conflict settings: all origins are allowed. AllowOriginFunc or AllowedOrigins is not needed")
+		return errors.New("conflict settings: all origins are allowed. AllowOriginFunc or AllowOrigins is not needed")
 	}
 	if !c.AllowAllOrigins && c.AllowOriginFunc == nil && len(c.AllowOrigins) == 0 {
 		return errors.New("conflict settings: all origins disabled")

--- a/cors_test.go
+++ b/cors_test.go
@@ -175,7 +175,7 @@ func TestGeneratePreflightHeaders_AllowCredentials(t *testing.T) {
 	assert.Len(t, header, 2)
 }
 
-func TestGeneratePreflightHeaders_AllowedMethods(t *testing.T) {
+func TestGeneratePreflightHeaders_AllowMethods(t *testing.T) {
 	header := generatePreflightHeaders(Config{
 		AllowMethods: []string{"GET ", "post", "PUT", " put  "},
 	})
@@ -184,7 +184,7 @@ func TestGeneratePreflightHeaders_AllowedMethods(t *testing.T) {
 	assert.Len(t, header, 2)
 }
 
-func TestGeneratePreflightHeaders_AllowedHeaders(t *testing.T) {
+func TestGeneratePreflightHeaders_AllowHeaders(t *testing.T) {
 	header := generatePreflightHeaders(Config{
 		AllowHeaders: []string{"X-user", "Content-Type"},
 	})
@@ -265,7 +265,7 @@ func TestValidateOrigin(t *testing.T) {
 	assert.True(t, cors.validateOrigin("chrome-extension://random-extension-id"))
 }
 
-func TestPassesAllowedOrigins(t *testing.T) {
+func TestPassesAllowOrigins(t *testing.T) {
 	router := newTestRouter(Config{
 		AllowOrigins:     []string{"http://google.com"},
 		AllowMethods:     []string{" GeT ", "get", "post", "PUT  ", "Head", "POST"},
@@ -331,7 +331,7 @@ func TestPassesAllowedOrigins(t *testing.T) {
 	assert.Empty(t, w.Header().Get("Access-Control-Max-Age"))
 }
 
-func TestPassesAllowedAllOrigins(t *testing.T) {
+func TestPassesAllowAllOrigins(t *testing.T) {
 	router := newTestRouter(Config{
 		AllowAllOrigins:  true,
 		AllowMethods:     []string{" Patch ", "get", "post", "POST"},


### PR DESCRIPTION
Should be no functional changes. Renaming only to maintain consistency with the `AllowOrigins`, `AllowMethods`, and `AllowHeaders` field names.