### PR TITLE
[Fix] parseWildcardRules removes the last non-asterisk character wrongly

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -135,7 +135,7 @@ func (c Config) parseWildcardRules() [][]string {
 			continue
 		}
 		if i == (len(o) - 1) {
-			wRules = append(wRules, []string{o[:i-1], "*"})
+			wRules = append(wRules, []string{o[:i], "*"})
 			continue
 		}
 


### PR DESCRIPTION
## Problem Description

For a pattern with asterisk as suffix, the `parseWildcardRules` forms the result array wrongly. 
i.e. for an allowed origin of `http://localhost*`, the `parseWildcardRules` returns the result as 
`[]string {"http://localhos", "*"}` instead of `[]string {"http://localhost", "*"}`

## Root Cause
The cause of this error is the code snippet 
https://github.com/gin-contrib/cors/blob/5f50d4fb4e0306dcacc6f8e9bea2dcee784dbbdf/cors.go#L138

The `i` is the index where asterisk character found and I think it should take a substring with end of `i` then the last non-asterisk character is kept.

## Solution
The solution is as this PR, using `i` to take the substring.

Please kindly review the change and accept it if this makes sense.

Thanks
