### PR TITLE
Same origin is not able to detected

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,7 +60,7 @@ func (cors *cors) applyCors(c *gin.Context) {
 		// request is not a CORS request
 		return
 	}
-	host := c.Request.Header.Get("Host")
+	host := c.Request.Host
 
 	if origin == "http://"+host || origin == "https://"+host {
 		// request is not a CORS request but have origin header.


### PR DESCRIPTION
Use `c.Request.Host` instead of `c.Request.Header.Get("Host")`.
`c.Request.Header.Get("Host")` returns "" 
ref: https://github.com/gin-gonic/gin/issues/616 gin v1.4.0