### PR TITLE
Fix detection of same origin

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,7 +60,7 @@ func (cors *cors) applyCors(c *gin.Context) {
 		// request is not a CORS request
 		return
 	}
-	host := c.Request.Header.Get("Host")
+	host := c.Request.Host
 
 	if origin == "http://"+host || origin == "https://"+host {
 		// request is not a CORS request but have origin header.


### PR DESCRIPTION
For incoming requests, the Host header is promoted to the
Request.Host field and removed from the Header map.

Therefore, it is Request.Host that needs to be compared against
the origin of a request.

Fixes: #60