### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: go
 
+arch:
+  - amd64
+  - ppc64le
+
+go:
+  - 1.13.x
+  - 1.14.x
+  - 1.15.x
+  - master
+
 jobs:
   fast_finish: true
   include:
@@ -7,10 +17,12 @@ jobs:
     env: GO111MODULE=on
   - go: 1.12.x
     env: GO111MODULE=on
-  - go: 1.13.x
-  - go: 1.14.x
-  - go: 1.15.x
-  - go: master
+  - arch: ppc64le
+    go: 1.11.x
+    env: GO111MODULE=on
+  - arch: ppc64le
+    go: 1.12.x
+    env: GO111MODULE=on
 
 script:
   - go test -v -covermode=atomic -coverprofile=coverage.out


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.