### PR TITLE
Document update

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -38,7 +38,7 @@ type Config struct {
 	// API specification
 	ExposeHeaders []string
 
-	// MaxAge indicates how long (in seconds) the results of a preflight request
+	// MaxAge indicates how long (with second-precision) the results of a preflight request 
 	// can be cached
 	MaxAge time.Duration
 


### PR DESCRIPTION
### Clarify doc for MaxAge in config:

Since `MaxAge` is a `time.Duration`, `in seconds` can be confusing for doc readers. Instead, it might be better to use `with second-precision`.