### PR TITLE
fixe(domain): wildcard parse bug

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -132,7 +132,7 @@ func (c Config) parseWildcardRules() [][]string {
 			continue
 		}
 		if i == (len(o) - 1) {
-			wRules = append(wRules, []string{o[:i-1], "*"})
+			wRules = append(wRules, []string{o[:i], "*"})
 			continue
 		}
 


### PR DESCRIPTION
I think there is a bug in the parseWildcardRules function - if the wildcard is at the end of the origin string, the character right before the wildcard is cut off, leading to potentially unwanted matches, for instance `https://example.com/*` would also validate anything on `https://example.community/*`.

For verification, just execute the code below:

```golang
package main

import (
	"errors"
	"strings"
)

type Config struct {
	AllowWildcard bool
	AllowOrigins  []string
}

func (c Config) parseWildcardRules() [][]string {
	var wRules [][]string

	if !c.AllowWildcard {
		return wRules
	}

	for _, o := range c.AllowOrigins {
		if !strings.Contains(o, "*") {
			continue
		}

		if c := strings.Count(o, "*"); c > 1 {
			panic(errors.New("only one * is allowed").Error())
		}

		i := strings.Index(o, "*")
		if i == 0 {
			wRules = append(wRules, []string{"*", o[1:]})
			continue
		}
		if i == (len(o) - 1) {
			wRules = append(wRules, []string{o[:i-1], "*"})
			continue
		}

		wRules = append(wRules, []string{o[:i], o[i+1:]})
	}

	return wRules
}

func main() {
	c1 := Config{AllowWildcard: true, AllowOrigins: []string{
		"https://example.com/*",
		"https://example.com/*/helloWorld",
		"*/helloWorld",
	}}

	wrules := c1.parseWildcardRules()
	for i, wr := range wrules {
		println(c1.AllowOrigins[i] + " ->")
		println(wr[0])
		println(wr[1])
		println()
	}
}
```

which results in
```
https://example.com/* ->
https://example.com                 # incorrect, should be https://example.com/
*

https://example.com/*/helloWorld ->
https://example.com/
/helloWorld

*/helloWorld ->
*
/helloWorld

```