### PR TITLE
allow preflight OPTIONS request without origin

### DIFF
--- a/config.go
+++ b/config.go
@@ -63,6 +63,11 @@ func (cors *cors) applyCors(c *gin.Context) {
 	origin := c.Request.Header.Get("Origin")
 	if len(origin) == 0 {
 		// request is not a CORS request
+		if c.Request.Method == "OPTIONS" {
+			// preflight request without origin
+			cors.handlePreflight(c)
+			c.AbortWithStatus(http.StatusNoContent) // Using 204 is better than 200 when the request status is OPTIONS
+		}
 		return
 	}
 	host := c.Request.Host


### PR DESCRIPTION
This fixes the issue #86 where requests for preflight without an origin set would result in 404. Now when a request with the OPTIONS method is sent without an origin, the `handlePreflight` method will be called.

Maybe this feature should not always be enabled, maybe we could instead have a config for it? I am happy to add this if needed.