### PR TITLE
Add "Access-Control-Allow-Origin" header to AllowHeaders

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -146,7 +146,7 @@ func (c Config) parseWildcardRules() [][]string {
 func DefaultConfig() Config {
 	return Config{
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"},
-		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type"},
+		AllowHeaders:     []string{"Access-Control-Allow-Origin", "Origin", "Content-Length", "Content-Type"},
 		AllowCredentials: false,
 		MaxAge:           12 * time.Hour,
 	}


### PR DESCRIPTION
When client sends Access-Control-Allow-Origin, server must respond  with the same domain(s). If not done, preflight response fails. 

With this change, `AllowHeaders` slice has `Access-Control-Allow-Origin` present, which does nod need any additional configuration and works out of the box on `cors.Default()`.

This is a fix to #84.