### PR TITLE
feat(schema): allow usage of custom schemas

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -51,6 +51,9 @@ type Config struct {
 	// Allows usage of popular browser extensions schemas
 	AllowBrowserExtensions bool
 
+	// Allows to add custom schema like tauri://
+	CustomSchemas []string
+
 	// Allows usage of WebSocket protocol
 	AllowWebSockets bool
 
@@ -86,6 +89,9 @@ func (c Config) getAllowedSchemas() []string {
 	}
 	if c.AllowFiles {
 		allowedSchemas = append(allowedSchemas, FileSchemas...)
+	}
+	if c.CustomSchemas != nil {
+		allowedSchemas = append(allowedSchemas, c.CustomSchemas...)
 	}
 	return allowedSchemas
 }

--- a/cors_test.go
+++ b/cors_test.go
@@ -271,6 +271,22 @@ func TestValidateOrigin(t *testing.T) {
 	assert.True(t, cors.validateOrigin("chrome-extension://random-extension-id"))
 }
 
+func TestValidateTauri(t *testing.T) {
+	c := Config{
+		AllowOrigins:           []string{"tauri://localhost:1234"},
+		AllowBrowserExtensions: true,
+	}
+	err := c.Validate()
+	assert.Equal(t, err.Error(), "bad origin: origins must contain '*' or include http://,https://,chrome-extension://,safari-extension://,moz-extension://,ms-browser-extension://")
+
+	c = Config{
+		AllowOrigins:           []string{"tauri://localhost:1234"},
+		AllowBrowserExtensions: true,
+		CustomSchemas:          []string{"tauri"},
+	}
+	assert.Nil(t, c.Validate())
+}
+
 func TestPassesAllowOrigins(t *testing.T) {
 	router := newTestRouter(Config{
 		AllowOrigins:     []string{"http://google.com"},


### PR DESCRIPTION
Allows projects to use custom schemas, that may not be foreseen by this project (or do not classify as browser extension necessarily).

Fixes #135 