### PR TITLE
test: improve CORS wildcard handling and testing

### DIFF
--- a/cors_test.go
+++ b/cors_test.go
@@ -414,3 +414,35 @@ func TestWildcard(t *testing.T) {
 	w = performRequest(router, "GET", "https://github.com")
 	assert.Equal(t, 200, w.Code)
 }
+
+func TestParseWildcardRules_NoWildcard(t *testing.T) {
+	config := Config{
+		AllowOrigins: []string{
+			"http://example.com",
+			"https://google.com",
+			"github.com",
+		},
+		AllowWildcard: false,
+	}
+
+	var expected [][]string
+
+	result := config.parseWildcardRules()
+
+	assert.Equal(t, expected, result)
+}
+
+func TestParseWildcardRules_InvalidWildcard(t *testing.T) {
+	config := Config{
+		AllowOrigins: []string{
+			"http://example.com",
+			"https://*.google.com*",
+			"*.github.com*",
+		},
+		AllowWildcard: true,
+	}
+
+	assert.Panics(t, func() {
+		config.parseWildcardRules()
+	})
+}


### PR DESCRIPTION
- Add two new test functions in `cors_test.go` for parsing wildcard rules: one without wildcards and one with invalid wildcards
- Ensure no wildcard rules are returned when `AllowWildcard` is set to false
- Verify that parsing invalid wildcard rules triggers a panic