### PR TITLE
Precompile origin regexes at middleware init

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ type cors struct {
 	allowOriginFunc            func(string) bool
 	allowOriginWithContextFunc func(*gin.Context, string) bool
 	allowOrigins               []string
+	allowOriginRegexes         []*regexp.Regexp
 	normalHeaders              http.Header
 	preflightHeaders           http.Header
 	wildcardOrigins            [][]string
@@ -55,12 +56,21 @@ func newCors(config Config) *cors {
 		config.OptionsResponseStatusCode = http.StatusNoContent
 	}
 
+	normalizedOrigins := normalize(config.AllowOrigins)
+	allowOriginRegexes := make([]*regexp.Regexp, len(normalizedOrigins))
+	for i, value := range normalizedOrigins {
+		if m := originRegex.FindStringSubmatch(value); m != nil {
+			allowOriginRegexes[i] = regexp.MustCompile(m[1])
+		}
+	}
+
 	return &cors{
 		allowOriginFunc:            config.AllowOriginFunc,
 		allowOriginWithContextFunc: config.AllowOriginWithContextFunc,
 		allowAllOrigins:            config.AllowAllOrigins,
 		allowCredentials:           config.AllowCredentials,
-		allowOrigins:               normalize(config.AllowOrigins),
+		allowOrigins:               normalizedOrigins,
+		allowOriginRegexes:         allowOriginRegexes,
 		normalHeaders:              generateNormalHeaders(config),
 		preflightHeaders:           generatePreflightHeaders(config),
 		wildcardOrigins:            config.parseWildcardRules(),
@@ -130,13 +140,14 @@ func (cors *cors) validateOrigin(origin string) bool {
 		return true
 	}
 
-	for _, value := range cors.allowOrigins {
-		if !originRegex.MatchString(value) && value == origin {
-			return true
+	for i, value := range cors.allowOrigins {
+		if cors.allowOriginRegexes[i] == nil {
+			if value == origin {
+				return true
+			}
+			continue
 		}
-
-		if originRegex.MatchString(value) &&
-			regexp.MustCompile(originRegex.FindStringSubmatch(value)[1]).MatchString(origin) {
+		if cors.allowOriginRegexes[i].MatchString(origin) {
 			return true
 		}
 	}


### PR DESCRIPTION

**Repo:** gin-contrib/cors (⭐ 2000)
**Type:** refactor
**Files changed:** 1
**Lines:** +18/-7

## What
Moves regex compilation for regex-based `AllowOrigins` entries out of the hot path. Previously, `validateOrigin` recompiled each regex entry via `regexp.MustCompile` on every incoming request, and also ran `originRegex.MatchString(value)` twice per entry (once to reject, once to accept). The new code compiles each regex once in `newCors` and caches a parallel `[]*regexp.Regexp` alongside `allowOrigins`, then uses a nil check in the hot path to discriminate literal vs regex entries.

## Why
`validateOrigin` runs on every CORS-bearing request. For any config that uses regex-form origins (e.g. `/^https:\/\/.*\.example\.com$/`), the previous implementation did N regex compilations per request. Regex compilation is not cheap and, more importantly, is completely redundant — the patterns are fixed at construction time. This is a straightforward hot-path cleanup with no behavioral change.

## Testing
- `go build ./...` — clean.
- `go test ./... -count=1` — all tests pass (including `TestValidateOrigin` which exercises the regex-matching path).

## Risk
Low — pure refactor; semantics of `validateOrigin` are preserved (literal equality for non-regex entries, regex match for regex entries). Test suite passes unchanged.
