### PR TITLE
fix: preserve original case of allowed methods in CORS preflight headers (fixes #121)

### DIFF
--- a/cors_test.go
+++ b/cors_test.go
@@ -199,7 +199,7 @@ func TestGeneratePreflightHeaders(t *testing.T) {
 		{
 			"AllowMethods set",
 			Config{AllowMethods: []string{"GET ", "post", "PUT", " put  "}},
-			map[string]string{"Access-Control-Allow-Methods": "GET,POST,PUT", "Vary": "Origin"},
+			map[string]string{"Access-Control-Allow-Methods": "GET,post,PUT,put", "Vary": "Origin"},
 			2,
 		},
 		{
@@ -452,7 +452,7 @@ func TestCORS_AllowOrigins_Preflight(t *testing.T) {
 		assert.Equal(t, http.StatusNoContent, w.Code)
 		assert.Equal(t, origin, w.Header().Get(testHeaderACAOrigin))
 		assert.Equal(t, "", w.Header().Get("Access-Control-Allow-Credentials"))
-		assert.Equal(t, "GET,POST,PUT,HEAD", w.Header().Get("Access-Control-Allow-Methods"))
+		assert.Equal(t, "GeT,get,post,PUT,Head,POST", w.Header().Get("Access-Control-Allow-Methods"))
 		assert.Equal(t, "Content-Type,Timestamp", w.Header().Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "43200", w.Header().Get("Access-Control-Max-Age"))
 	}
@@ -503,7 +503,7 @@ func TestPassesAllowAllOrigins(t *testing.T) {
 	w = performRequest(router, http.MethodOptions, testOriginFacebook)
 	assert.Equal(t, http.StatusNoContent, w.Code)
 	assert.Equal(t, "*", w.Header().Get(testHeaderACAOrigin))
-	assert.Equal(t, "PATCH,GET,POST", w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "Patch,get,post,POST", w.Header().Get("Access-Control-Allow-Methods"))
 	assert.Equal(t, "Content-Type,Testheader", w.Header().Get("Access-Control-Allow-Headers"))
 	assert.Equal(t, "36000", w.Header().Get("Access-Control-Max-Age"))
 	assert.Empty(t, w.Header().Get("Access-Control-Allow-Credentials"))

--- a/utils.go
+++ b/utils.go
@@ -32,7 +32,7 @@ func generatePreflightHeaders(c Config) http.Header {
 		headers.Set("Access-Control-Allow-Credentials", "true")
 	}
 	if len(c.AllowMethods) > 0 {
-		allowMethods := convert(normalize(c.AllowMethods), strings.ToUpper)
+		allowMethods := deduplicateAndTrim(c.AllowMethods)
 		value := strings.Join(allowMethods, ",")
 		headers.Set("Access-Control-Allow-Methods", value)
 	}
@@ -87,4 +87,20 @@ func convert(s []string, c converter) []string {
 		out = append(out, c(i))
 	}
 	return out
+}
+
+func deduplicateAndTrim(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(values))
+	var deduped []string
+	for _, v := range values {
+		trimmed := strings.TrimSpace(v)
+		if _, ok := seen[trimmed]; !ok {
+			seen[trimmed] = true
+			deduped = append(deduped, trimmed)
+		}
+	}
+	return deduped
 }


### PR DESCRIPTION
Fixes #121

The Fetch standard states that HTTP methods are case-sensitive (e.g., PATCH is distinct from patch). The CORS middleware was uppercasing all methods before writing to Access-Control-Allow-Methods, which prevented users from allowing non-uppercase methods.

The fix:
- Replaces the normalize+ToUpper pipeline with a new deduplicateAndTrim function that only trims whitespace and deduplicates, preserving original case
- Updates test assertions that were asserting incorrect uppercase output

This aligns with the Fetch spec and common CORS middleware behavior.
